### PR TITLE
Replace blast by diamond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.nextflow*
+work/
+conda/
+example/*dmnd
+results/

--- a/deprecated/blast_old.nf
+++ b/deprecated/blast_old.nf
@@ -14,8 +14,8 @@ process blast {
     
     script:
     """
-    diamond makedb --in ${fasta2} -d ${fasta2}.dmnd 
-    diamond blastp  -p ${task.cpus} -q ${fasta} -d ${fasta2}.dmnd -e ${params.evalue} --outfmt "6 qseqid sseqid pident length mismatch gapopen qstart qend qlen sstart send evalue bitscore slen" | awk '{if(\$3>${params.seqidentity*100} && \$4>(\$9*${params.alnlength})){print \$0}}' > ${name}-query-${name2}-db.blast
+    makeblastdb -in ${fasta2} -dbtype prot #-parse_seqids
+    blastp -task blastp -num_threads ${task.cpus} -query ${fasta} -db ${fasta2} -evalue ${params.evalue} -outfmt "6 qseqid sseqid pident length mismatch gapopen qstart qend qlen sstart send evalue bitscore slen" | awk '{if(\$3>${params.seqidentity*100} && \$4>(\$9*${params.alnlength})){print \$0}}' > ${name}-query-${name2}-db.blast
     awk '{print \$1}' ${name}-query-${name2}-db.blast | sort | uniq | wc -l | awk '{print \$1}' > ${name}-query-${name2}-db.blast.hits
     echo "\t${name}:\tFound \$(cat ${name}-query-${name2}-db.blast.hits) matches with an E value of less than ${params.evalue}, a sequence identity of more than ${params.seqidentity*100}%, and an alignable region of the query protein sequence of more than ${params.alnlength*100}%."
 

--- a/deprecated/blast_old.yaml
+++ b/deprecated/blast_old.yaml
@@ -2,6 +2,5 @@ name: blast
 channels:
   - bioconda
 dependencies:
-  - diamond=2.1
-  - python=3.8
+  - blast=2.9.0
   

--- a/modules/blast.nf
+++ b/modules/blast.nf
@@ -15,7 +15,7 @@ process blast {
     script:
     """
     diamond makedb --in ${fasta2} -d ${fasta2}.dmnd 
-    diamond blastp  -p ${task.cpus} -q ${fasta} -d ${fasta2}.dmnd -e ${params.evalue} --outfmt "6 qseqid sseqid pident length mismatch gapopen qstart qend qlen sstart send evalue bitscore slen" | awk '{if(\$3>${params.seqidentity*100} && \$4>(\$9*${params.alnlength})){print \$0}}' > ${name}-query-${name2}-db.blast
+    diamond blastp --ultra-sensitive -p ${task.cpus} -q ${fasta} -d ${fasta2}.dmnd -e ${params.evalue} --outfmt "6 qseqid sseqid pident length mismatch gapopen qstart qend qlen sstart send evalue bitscore slen" | awk '{if(\$3>${params.seqidentity*100} && \$4>(\$9*${params.alnlength})){print \$0}}' > ${name}-query-${name2}-db.blast
     awk '{print \$1}' ${name}-query-${name2}-db.blast | sort | uniq | wc -l | awk '{print \$1}' > ${name}-query-${name2}-db.blast.hits
     echo "\t${name}:\tFound \$(cat ${name}-query-${name2}-db.blast.hits) matches with an E value of less than ${params.evalue}, a sequence identity of more than ${params.seqidentity*100}%, and an alignable region of the query protein sequence of more than ${params.alnlength*100}%."
 


### PR DESCRIPTION
Hi @hoelzer,
Just a small pull request to replace Blast with Diamond.
Diamond is much faster than blast with similar sensitivity (https://www.nature.com/articles/s41592-021-01101-x) and I want to compare a lot of genomes so a speed bump is very much appreciated
Best
Greg