### PR TITLE
Implement one-vs-all comparisons 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/martinhoelzer.svg?style=social)](https://twitter.com/martinhoelzer) 
 
-__Update 2023/05: Re-implementation as a [Nextflow pipeline](nextflow.io). Please feel free to report any [issues](https://github.com/hoelzer/pocp/issues)!__
+__Update 2023/12: One-vs-All comparisons are now possible in genome and protein input mode. Check `--help` message.__
 
 __Update 2023/10: Now using [Diamond](https://www.nature.com/articles/s41592-021-01101-x) instead of Blast for protein alignments. Thx [@michoug](https://github.com/michoug) for the Pull Request.__
 
-__Update 2023/12: One-vs-All comparisons are now possible in genome and protein input mode. Check `--help` message`.__
+__Update 2023/05: Re-implementation as a [Nextflow pipeline](nextflow.io). Please feel free to report any [issues](https://github.com/hoelzer/pocp/issues)!__
 
 As input use one amino acid sequence FASTA file per genome such as provided by
 [Prokka](https://github.com/tseemann/prokka) or genome FASTA files which will be then annotated via [Prokka](https://github.com/tseemann/prokka). 
@@ -55,4 +55,4 @@ adjusted:
 --alnlength 0.5
 ```
 
-Please note that per default an "all-vs-all" comparison is performed based on the provided FASTA files. However, you can also switch to an "one-vs-all" comparison by additionally providing a single genome FASTA via `--genome` next to the `--genomes` directory **or** a single protein multi-FASTA via `--protein` next to the `--proteins` directory. In both cases, only "one-vs-all" comparisons will be performed.   
+Please note that per default an "all-vs-all" comparison is performed based on the provided FASTA files. However, you can also switch to an "one-vs-all" comparison by additionally providing a single genome FASTA via `--genome` next to the `--genomes` input **or** a single protein multi-FASTA via `--protein` next to the `--proteins` input. In both cases, only "one-vs-all" comparisons will be performed. It is also possible to combine `--genomes` with a target `--protein` FASTA for "one-vs-all" and vice versa. 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ nextflow info hoelzer/pocp
 nextflow run hoelzer/pocp -r 2.2.0 --help
 
 # example with genome files as input, all-vs-all comparison, performing a local execution and using Docker
-nextflow run hoelzer/pocp -r 2.2.0 --genomes 'example/*.fasta' -profile local,docker
+nextflow run hoelzer/pocp -r 2.2.0 --genomes $HOME'/.nextflow/assets/hoelzer/pocp/example/*.fasta' -profile local,docker
 
 # example with protein FASTA files as input (e.g. from Prokka pre-calculated), all-vs-all comparison, performing a SLURM execution and using conda
-nextflow run hoelzer/pocp -r 2.2.0 --proteins 'example/*.faa' -profile slurm,conda
+nextflow run hoelzer/pocp -r 2.2.0 --proteins $HOME'/.nextflow/assets/hoelzer/pocp/example/*.faa' -profile slurm,conda
 
 # example with genome files as input, additional genome file to activate one-vs-all comparison, performing a local execution and using Docker
-nextflow run hoelzer/pocp -r 2.2.0 --genomes 'example/*.fasta' --genome example/Cav_10DC88.fasta -profile local,docker
+nextflow run hoelzer/pocp -r 2.2.0 --genomes $HOME'/.nextflow/assets/hoelzer/pocp/example/*.fasta' --genome $HOME/.nextflow/assets/hoelzer/pocp/example/Cav_10DC88.fasta -profile local,docker
 ```
 
 The final output (`pocp-matrix.tsv`) should look like this (here, the resulting TSV was imported into Numbers on MacOS):

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ __Update 2023/05: Re-implementation as a [Nextflow pipeline](nextflow.io). Pleas
 
 __Update 2023/10: Now using [Diamond](https://www.nature.com/articles/s41592-021-01101-x) instead of Blast for protein alignments. Thx [@michoug](https://github.com/michoug) for the Pull Request.__
 
+__Update 2023/12: One-vs-All comparisons are now possible in genome and protein input mode. Check `--help` message`.__
+
 As input use one amino acid sequence FASTA file per genome such as provided by
 [Prokka](https://github.com/tseemann/prokka) or genome FASTA files which will be then annotated via [Prokka](https://github.com/tseemann/prokka). 
-The pipeline will then calculate all pairwise alignments between all protein sequences and use this
-information for POCP calculation following [Qin, Xie _et al_.
-2014](https://www.ncbi.nlm.nih.gov/pubmed/24706738). 
+The pipeline will then calculate all-vs-all pairwise alignments between all protein sequences and use this
+information for POCP calculation following [Qin, Xie _et al_. 2014](https://www.ncbi.nlm.nih.gov/pubmed/24706738). For one-vs-all comparisons see below.
 
 You only need `nextflow` and `conda` or `mamba` or `docker` or `singularity` to run the pipeline. I recommend using `docker`. Then install and run the pipeline:
 
@@ -25,17 +26,20 @@ You only need `nextflow` and `conda` or `mamba` or `docker` or `singularity` to 
 # get the pipeline code
 nextflow pull hoelzer/pocp 
 
-# check availble release versions and development branches
+# check availble release versions and development branches, recommend to use latest release
 nextflow info hoelzer/pocp 
 
 # get the help page and define a release version. ATTENTION: use latest version. 
-nextflow run hoelzer/pocp -r 2.1.0 --help
+nextflow run hoelzer/pocp -r 2.2.0 --help
 
-# example with genome files as input, performing a local execution and using Docker
-nextflow run hoelzer/pocp -r 2.1.0 --genomes 'example/*.fasta' -profile local,docker
+# example with genome files as input, all-vs-all comparison, performing a local execution and using Docker
+nextflow run hoelzer/pocp -r 2.2.0 --genomes 'example/*.fasta' -profile local,docker
 
-# example with protein FASTA files as input (e.g. from Prokka pre-calculated), performing a SLURM execution and using conda
-nextflow run hoelzer/pocp -r 2.1.0 --proteins 'example/*.faa' -profile slurm,conda
+# example with protein FASTA files as input (e.g. from Prokka pre-calculated), all-vs-all comparison, performing a SLURM execution and using conda
+nextflow run hoelzer/pocp -r 2.2.0 --proteins 'example/*.faa' -profile slurm,conda
+
+# example with genome files as input, additional genome file to activate one-vs-all comparison, performing a local execution and using Docker
+nextflow run hoelzer/pocp -r 2.2.0 --genomes 'example/*.fasta' --genome example/Cav_10DC88.fasta -profile local,docker
 ```
 
 The final output (`pocp-matrix.tsv`) should look like this (here, the resulting TSV was imported into Numbers on MacOS):
@@ -50,3 +54,5 @@ adjusted:
 --seqidentity 0.4
 --alnlength 0.5
 ```
+
+Please note that per default an "all-vs-all" comparison is performed based on the provided FASTA files. However, you can also switch to an "one-vs-all" comparison by additionally providing a single genome FASTA via `--genome` next to the `--genomes` directory **or** a single protein multi-FASTA via `--protein` next to the `--proteins` directory. In both cases, only "one-vs-all" comparisons will be performed.   

--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ adjusted:
 ```
 
 Please note that per default an "all-vs-all" comparison is performed based on the provided FASTA files. However, you can also switch to an "one-vs-all" comparison by additionally providing a single genome FASTA via `--genome` next to the `--genomes` input **or** a single protein multi-FASTA via `--protein` next to the `--proteins` input. In both cases, only "one-vs-all" comparisons will be performed. It is also possible to combine `--genomes` with a target `--protein` FASTA for "one-vs-all" and vice versa. 
+
+If you use the POCP Nextflow pipeline, please cite the original POCP study that introduced the metric and the POCP-nf pipeline:
+
+**[Qin, Qi-Long, _et al_. "A proposed genus boundary for the prokaryotes based on genomic insights." Journal of bacteriology 196.12 (2014): 2210-2215.](https://pubmed.ncbi.nlm.nih.gov/24706738/)**
+
+**[Martin Hölzer. "POCP: An automatic Nextflow pipeline for calculating the percentage of conserved proteins in bacterial taxonomy". SOME JOURNAL. Hopefully in 2024.]()**

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,9 @@ params {
     genomes = ''
     proteins = ''
     list = false
+    // for one-vs-all switch
+    genome = false
+    protein = false
 
     // Prokka
     gcode = 0


### PR DESCRIPTION
Solves #13 

Via providing an additional target genome FASTA (`--genome`) or target protein FASTA (`--protein`), the POCP values will only be calculated in a one-vs-all fashion. 